### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/agent_flow/py.typed
+++ b/agent_flow/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker file


### PR DESCRIPTION
Adds the `py.typed` marker file so that type checkers like mypy and pyright recognize this package as typed when installed.

This is a standard practice for typed Python packages per [PEP 561](https://peps.python.org/pep-0561/).